### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload static site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@ Aucun serveur n'est requis : tout fonctionne côté client.
 
 ## Publication sur GitHub Pages
 
+### Déploiement automatique via GitHub Actions (recommandé)
+
 1. Créez un dépôt GitHub et poussez-y ces fichiers (`git init`, `git add .`, `git commit`, `git branch -M main`, `git remote add origin`, `git push origin main`).
-2. Dans GitHub, ouvrez **Settings → Pages**.
-3. Dans la section **Build and deployment**, choisissez **Deploy from a branch**.
-4. Sélectionnez la branche `main` et le dossier `/ (root)` puis sauvegardez.
-5. Patientez quelques minutes que GitHub génère le site. L'URL publique est affichée dans la section Pages (format `https://<votre-utilisateur>.github.io/<nom-du-dépôt>/`).
+2. Le workflow `.github/workflows/deploy-pages.yml` publiera automatiquement le site sur GitHub Pages à chaque push sur `main`.
+3. Lors du premier déploiement, ouvrez **Settings → Pages**, vérifiez que la source est **GitHub Actions** et sauvegardez si nécessaire.
+4. Le statut et l'URL publique sont visibles dans l'onglet **Actions** puis dans **Pages** (format `https://<votre-utilisateur>.github.io/<nom-du-dépôt>/`).
+
+### Déploiement manuel (alternative)
+
+1. Dans GitHub, ouvrez **Settings → Pages**.
+2. Dans la section **Build and deployment**, choisissez **Deploy from a branch**.
+3. Sélectionnez la branche `main` et le dossier `/ (root)` puis sauvegardez.
+4. Patientez quelques minutes que GitHub génère le site. L'URL publique est affichée dans la section Pages.
 
 Les chemins relatifs déjà présents permettent un fonctionnement direct sur GitHub Pages. Pensez à personnaliser les textes (contact, coefficients) avant la mise en ligne publique.
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to publish the static site to GitHub Pages on every push to main
- document the automatic deployment process and manual fallback in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d95315906883239cc816d934e4213f